### PR TITLE
Add option to exclude metadata types from backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,15 @@ Groovy Version: 2.1.5 JVM: 1.7.0_51 Vendor: Oracle Corporation OS: Linux
 - Open command prompt and enter command `ant backupMetadata`
 
 The results will be downloaded to `build/metadata`
+
+
+## How to exclude types from backup
+To exclude specific metadata types from backup you can specify a comma list of 
+metadata types in the `build.properties`.
+
+For example to exclude Reports and Documents form backup add the following line
+to `build.properties`
+
+```
+sf.excludeTypes=Report,Document
+```

--- a/ant-includes/default.properties
+++ b/ant-includes/default.properties
@@ -5,3 +5,11 @@ sf.batchSize = 20
 
 # The version of the antlib jar in lib
 sf.antlib.version = 39.0
+
+# Use 'https://login.salesforce.com' for production or developer edition
+# Use 'https://test.salesforce.com for sandbox.
+sf.serverurl = https://login.salesforce.com
+
+
+# Comma seperated list of metadata types that should be excluded from retrieval
+sf.excludeTypes =

--- a/build.sample.properties
+++ b/build.sample.properties
@@ -1,5 +1,5 @@
 # build.properties
-#
+# See ant-includes/default.properies for other properties that can be defined
 
 # Specify the login credentials for the desired Salesforce organization
 sf.username = 


### PR DESCRIPTION
Users can specify a comma seperated list of metadata types that should
be excluded from the retrieval of metadata from Salesforce.

This will allow for scenarios where certain metadata types are
problematic possibly producing UNKNOWN_EXCEPTION due to bugs in
Salesforce.

It should also allow for some flexibility in the way backups are preformed.

Fixes #53