### PR TITLE
Added LeadConvertSettings

### DIFF
--- a/force-meta-backup.groovy
+++ b/force-meta-backup.groovy
@@ -385,7 +385,7 @@ class BulkMetadataManifestBuilder extends ManifestBuilder {
         'HomePageLayout',
         'InstalledPackage',
         'KeywordList',
-        'LeadConvertSettings'
+        'LeadConvertSettings',
         'LightningExperienceTheme',
         'LiveChatAgentConfig',
         'LiveChatButton',

--- a/force-meta-backup.groovy
+++ b/force-meta-backup.groovy
@@ -385,6 +385,7 @@ class BulkMetadataManifestBuilder extends ManifestBuilder {
         'HomePageLayout',
         'InstalledPackage',
         'KeywordList',
+        'LeadConvertSettings'
         'LightningExperienceTheme',
         'LiveChatAgentConfig',
         'LiveChatButton',


### PR DESCRIPTION
LeadConvertSettings is available in API versions 39.0 and later.
https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_leadconvertsettings.htm